### PR TITLE
Remove default hostname from Postgres metrics

### DIFF
--- a/plugins/postgres/postgres-connections-metric.rb
+++ b/plugins/postgres/postgres-connections-metric.rb
@@ -32,8 +32,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',

--- a/plugins/postgres/postgres-dbsize-metric.rb
+++ b/plugins/postgres/postgres-dbsize-metric.rb
@@ -32,8 +32,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',

--- a/plugins/postgres/postgres-locks-metric.rb
+++ b/plugins/postgres/postgres-locks-metric.rb
@@ -32,8 +32,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',

--- a/plugins/postgres/postgres-statsbgwriter-metric.rb
+++ b/plugins/postgres/postgres-statsbgwriter-metric.rb
@@ -32,8 +32,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',

--- a/plugins/postgres/postgres-statsdb-metric.rb
+++ b/plugins/postgres/postgres-statsdb-metric.rb
@@ -33,8 +33,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',

--- a/plugins/postgres/postgres-statsio-metric.rb
+++ b/plugins/postgres/postgres-statsio-metric.rb
@@ -33,8 +33,7 @@ class PostgresStatsIOMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',

--- a/plugins/postgres/postgres-statstable-metric.rb
+++ b/plugins/postgres/postgres-statstable-metric.rb
@@ -33,8 +33,7 @@ class PostgresStatsTableMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',


### PR DESCRIPTION
Remove the default hostname from the Postgres metric scripts as these
will not work work with the passwordless 'peer' authentication method

Note: this branch is what's used by sensu clients currently, it just never got merged into master for whatever reason.

[ID-1157]