### PR TITLE
Fix check-es-cluster-status

### DIFF
--- a/plugins/elasticsearch/check-es-cluster-status.rb
+++ b/plugins/elasticsearch/check-es-cluster-status.rb
@@ -60,7 +60,7 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
          default: 30
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     critical 'Connection refused'
@@ -77,7 +77,7 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
 
   def master?
     if Gem::Version.new(acquire_es_version) >= Gem::Version.new('1.0.0')
-      master = get_es_resource('_cluster/state/master_node')['master_node']
+      master = get_es_resource('/_cluster/state/master_node')['master_node']
       local = get_es_resource('/_nodes/_local')
     else
       master = get_es_resource('/_cluster/state?filter_routing_table=true&filter_metadata=true&filter_indices=true')['master_node']


### PR DESCRIPTION
This check stopped working on ES 5.x, although it looks like it
should've been failing earlier.  This is likely due to ES being more
strict with parsing of REST queries.

[ID-1157]